### PR TITLE
Make channelName optional for events triggered on channel instance

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,11 +83,12 @@ export class PusherChannel {
     });
   }
 
-  async trigger(event: PusherEvent) {
-    if (event.channelName !== this.channelName) {
+  async trigger(event: Omit<PusherEvent, 'channelName'> & Partial<Pick<PusherEvent, 'channelName'>>) {
+    const channelName = event.channelName ?? this.channelName
+    if (channelName !== this.channelName) {
       throw 'Event is not for this channel';
     }
-    return Pusher.getInstance().trigger(event);
+    return Pusher.getInstance().trigger({ ...event, channelName });
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,7 +84,7 @@ export class PusherChannel {
   }
 
   async trigger(event: Omit<PusherEvent, 'channelName'> & Partial<Pick<PusherEvent, 'channelName'>>) {
-    const channelName = event.channelName ?? this.channelName
+    const channelName = event.channelName ?? this.channelName;
     if (channelName !== this.channelName) {
       throw 'Event is not for this channel';
     }


### PR DESCRIPTION
## Description

Currently the readme allows for triggering events on the channel instance without specifying the `channelName` property. This makes sense, so this implements that functionality.

## CHANGELOG

* [CHANGED] Make channelName optional for events triggered on channel instance