### PR TITLE
fix:add optional chaining to channel in

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -193,7 +193,7 @@ export class Pusher {
         default:
           const pusherEvent = new PusherEvent(event);
           args.onEvent?.(pusherEvent);
-          channel.onEvent?.(pusherEvent);
+          channel?.onEvent?.(pusherEvent);
           break;
       }
     });


### PR DESCRIPTION
onEvent listener

## Description

- in the `onEvent` listener, add optional chaining to the channel variable

## CHANGELOG

* [CHANGED] Fixed crash when `channel.onEvent` is undefined in `onEvent` listener