### PR TITLE
Fix #43 / override RCTEventEmitter init

### DIFF
--- a/ios/PusherWebsocketReactNative.swift
+++ b/ios/PusherWebsocketReactNative.swift
@@ -32,7 +32,7 @@ import Foundation
     }
 
     func callback(name:String, body:Any) -> Void {
-        PusherWebsocketReactNative.shared?.sendEvent(withName:vendorEventName, body:body)
+        PusherWebsocketReactNative.shared?.sendEvent(name:vendorEventName, body:body)
     }
 
     func initialize(_ args:[String: Any], resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) {

--- a/ios/PusherWebsocketReactNative.swift
+++ b/ios/PusherWebsocketReactNative.swift
@@ -3,6 +3,14 @@ import Foundation
 
 @objc(PusherWebsocketReactNative)
 @objcMembers class PusherWebsocketReactNative: RCTEventEmitter, PusherDelegate, Authorizer {
+
+    public static var shared: PusherWebsocketReactNative?
+
+    override init() {
+        super.init()
+        PusherWebsocketReactNative.shared = self
+    }
+
     private var pusher: Pusher!
 
     private var authorizerMutex = [String : DispatchSemaphore]()
@@ -24,7 +32,7 @@ import Foundation
     }
 
     func callback(name:String, body:Any) -> Void {
-        self.sendEvent(withName:name, body:body)
+        PusherWebsocketReactNative.shared?.sendEvent(withName:vendorEventName, body:body)
     }
 
     func initialize(_ args:[String: Any], resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) {


### PR DESCRIPTION
## Description

Issue #43 

I experienced some crashes when receiving notifications, with xcode displaying the following error message:
```
RCTCallableJSModules is not set. This is probably because you've explicitly synthesized the RCTCallableJSModules in PusherWebsocketReactNative, even though it's inherited from RCTEventEmitter.'
```
I also experienced websocket conflicts with the react-native debugger, causing the sourcemaps to be not sync with metro

I was able to reproduce this crash using the app's example and following those steps:

- Compile the app in OSX simulator
- Send a notification -> OK
- Open Developer Menu (`⌘D`)
- Press `Stop Debugging`
- Open Developer Menu (`⌘D`)
- Press `Debug With Chrome`
- Send a notification -> Crash

I investigated further and stumbled upon those stack overflow issues:
https://stackoverflow.com/questions/71302327/react-native-call-native-swift-function-that-calls-another-function-that-trigg
https://stackoverflow.com/questions/73717607/react-native-how-can-i-send-events-from-ios-swift-back-to-javascript

It appears that  everytimes`PusherWebsocketReactNative` was instanciated, RCTEvent was re-initialised even thought it was already created assigned it to the bridge.

overriding init and calling an instance directly fix the problem

## CHANGELOG

* [CHANGED] Override RCTEventEmitter init