### PR TITLE
events: Suppress "foreign" event handling

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -191,6 +191,14 @@ export class Pusher {
           channel.onSubscriptionCount?.(decodedData.subscription_count);
           break;
         default:
+
+          // Channel not found
+          // Possibly channelName not provided, because other library / dependency sent same event with different data.
+          // Even if we use prefix on event names, then other libraries or current library extensions can easily broke 
+          // this with sending event without required parameters - channelName, eventName etc..
+          // Ensure channel exists, before moving forward
+          if(!channel) return;
+          
           const pusherEvent = new PusherEvent(event);
           args.onEvent?.(pusherEvent);
           channel.onEvent?.(pusherEvent);


### PR DESCRIPTION
Hello, Guys!

## Description

onEvent listener can catch events, dispatched from other libraries, using native event emitter. This can make things broken, when using Pusher with other libraries or simple libraries, who extend Pusher's one and using same event names.

`TypeError: undefined is not an object (evaluating 'channel.onEvent')`

According to Pusher docs: 

> Events are the primary method of packaging messages in the Channels system. They form the basis of all communication.

We can suppress onEvent callback if there's no channel found.

## CHANGELOG

* [CHANGED] When executing onEvent callback in channel, ensure channel exists.