### PR TITLE
Add dependency on React-Core for fixing RN 0.71.2

### DIFF
--- a/pusher-websocket-react-native.podspec
+++ b/pusher-websocket-react-native.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'PusherSwift', '~> 10.1.1'
   s.dependency 'React'
+  s.dependency 'React-Core'
   s.framework    = 'Network'
   s.swift_version = '5'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Description

Adding a dependency on React-Core to avoid the Undefined symbol: _RCTEventEmitter error, which seems to be in React-Core.

<img width="546" alt="Screenshot 2023-02-25 at 9 12 39 PM" src="https://user-images.githubusercontent.com/3887118/221393574-0498b3ad-749f-4bab-afcc-d3a63413be1b.png">

## CHANGELOG

* [FIXED] Add React-Core dependency to fix Undefined symbol: _RCTEventEmitter