### PR TITLE
fix: wait for unsub before deleting local channel

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -294,8 +294,8 @@ export class Pusher {
   }
 
   public async unsubscribe({ channelName }: { channelName: string }) {
-    this.channels.delete(channelName);
     await PusherWebsocketReactNative.unsubscribe(channelName);
+    this.channels.delete(channelName);
   }
 
   public async trigger(event: PusherEvent) {


### PR DESCRIPTION
## Description

Local channels map is updated before awaiting actual sub/unsub. It becomes a problem with unsubscriptions. The channel is deleted from local map before actually unsubscribing. If a new message is received between unsub is triggered and unsub finishes, it throws an error. Because `this.channels.get('channel')` is undefined during that period.

This is solving the same issue mentioned in #87 

## CHANGELOG

* [CHANGED] Reordered removing channel from local channels map and waiting for native side to do unsubscribing.