### PR TITLE
Do not throw exception when user subscribes to a channel twice

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -209,7 +209,7 @@ export class Pusher {
         default:
           const pusherEvent = new PusherEvent(event);
           args.onEvent?.(pusherEvent);
-          channel.onEvent?.(pusherEvent);
+          channel?.onEvent?.(pusherEvent);
           break;
       }
     });
@@ -287,10 +287,16 @@ export class Pusher {
     onMemberRemoved?: (member: PusherMember) => void;
     onEvent?: (event: PusherEvent) => void;
   }) {
-    const channel = new PusherChannel(args);
-    this.channels.set(args.channelName, channel);
+    const channel = this.channels.get(args.channelName)
+    
+    if (channel) {
+      return channel;
+    }
+
+    const newChannel = new PusherChannel(args);
     await PusherWebsocketReactNative.subscribe(args.channelName);
-    return channel;
+    this.channels.set(args.channelName, newChannel);
+    return newChannel;
   }
 
   public async unsubscribe({ channelName }: { channelName: string }) {


### PR DESCRIPTION
## Description

Do not throw an exception when a user subscribes to a channel twice. It only happens on Android that throws an IllegalArgumentException. This PR handles the RN side by checking whether a subscribed channel is already on the subscription map.

## CHANGELOG

* [FIXED] Crash when a user subscribes to a channel twice on Android