### PR TITLE
Bump pusher-websocket-swift library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.3
+
+* [CHANGED] Bump pusher-websocket-swift SDK to 10.1.3
+* [FIXED] Crash when receiving an event while the app is in background 
+
 ## 1.2.2
 
 * [FIXED] Crash when a user subscribes to a channel twice on Android

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -75,13 +75,13 @@ PODS:
   - glog (0.3.5)
   - hermes-engine (0.70.5)
   - libevent (2.1.12)
-  - NWWebSocket (0.5.2)
+  - NWWebSocket (0.5.3)
   - OpenSSL-Universal (1.1.1100)
-  - pusher-websocket-react-native (1.1.1):
-    - PusherSwift (~> 10.1.1)
+  - pusher-websocket-react-native (1.2.2):
+    - PusherSwift (~> 10.1.3)
     - React
-  - PusherSwift (10.1.1):
-    - NWWebSocket (~> 0.5.2)
+  - PusherSwift (10.1.3):
+    - NWWebSocket (~> 0.5.3)
     - TweetNacl (~> 1.0.0)
   - RCT-Folly (2021.07.22.00):
     - boost
@@ -544,7 +544,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: affa4ba1bfdaac110a789192f4d452b053a86624
   FBReactNativeSpec: fe8b5f1429cfe83a8d72dc8ed61dc7704cac8745
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -557,13 +557,13 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 476ee3e89abb49e07f822b48323c51c57124b572
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 7fe5fc6ef707b7fdcb161b63898ec500e285653d
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  NWWebSocket: 21f0c73639815da3272862c912275b26102aa80c
+  NWWebSocket: 05fc4419102f33934f87157d70228837e327064f
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  pusher-websocket-react-native: f39fffc44df8914ca5c9382a0acb446130d9946e
-  PusherSwift: 70a805a950ab49381e164c54ac19c3b9c1d288e3
+  pusher-websocket-react-native: ee031d72ed7ecd0d35b22f7f76203ca0df2908bb
+  PusherSwift: 9083be278b87d2325c0fd8c4bdad0f54ffa8931a
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: 21229f84411088e5d8538f21212de49e46cc83e2
   RCTTypeSafety: 62eed57a32924b09edaaf170a548d1fc96223086
@@ -599,4 +599,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d982d74711b8c9a54ff13a4f593f7931fb31358f
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pusher/pusher-websocket-react-native",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Pusher Channels Client for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/pusher-websocket-react-native.podspec
+++ b/pusher-websocket-react-native.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   s.requires_arc = true
-  s.dependency 'PusherSwift', '~> 10.1.1'
+  s.dependency 'PusherSwift', '~> 10.1.3'
   s.dependency 'React'
   s.framework    = 'Network'
   s.swift_version = '5'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -186,11 +186,14 @@ export class Pusher {
           // Depending on the platform implementation we get json or a Map.
           var decodedData = data instanceof Object ? data : JSON.parse(data);
           for (const _userId in decodedData?.presence?.hash) {
-            const userInfo = decodedData?.presence?.hash[_userId];
-            var member = new PusherMember(_userId, userInfo);
-            channel.members.set(member.userId, member);
-            if (_userId === userId) {
-              channel.me = member;
+            if (channel) {
+              const userInfo = decodedData?.presence?.hash[_userId];
+              var member = new PusherMember(_userId, userInfo);
+              channel.members?.set(member.userId, member);
+
+              if (_userId === userId) {
+                channel.me = member;
+              }
             }
           }
           args.onSubscriptionSucceeded?.(channelName, decodedData);


### PR DESCRIPTION
## Description

* Bump `pusher-websocket-swift` SDK to 10.1.3
* `channel` null-check on `pusher:subscription_succeeded`

## CHANGELOG

* [CHANGED] Bump pusher-websocket-swift SDK to 10.1.3
* [FIXED] Crash when receiving an event while the app is in background 