### PR TITLE
fix: channel can be undefined, don't force it

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -115,7 +115,12 @@ export default function App() {
     log(
       `onSubscriptionSucceeded: ${channelName} data: ${JSON.stringify(data)}`
     );
-    const channel: PusherChannel = pusher.getChannel(channelName);
+    const channel: PusherChannel | undefined = pusher.getChannel(channelName);
+
+    if (!channel) {
+      return;
+    }
+
     const me = channel.me;
     onChangeMembers([...channel.members.values()]);
     log(`Me: ${me}`);
@@ -144,13 +149,23 @@ export default function App() {
 
   const onMemberAdded = (channelName: string, member: PusherMember) => {
     log(`onMemberAdded: ${channelName} user: ${member}`);
-    const channel: PusherChannel = pusher.getChannel(channelName);
+    const channel: PusherChannel | undefined = pusher.getChannel(channelName);
+
+    if (!channel) {
+      return;
+    }
+
     onChangeMembers([...channel.members.values()]);
   };
 
   const onMemberRemoved = (channelName: string, member: PusherMember) => {
     log(`onMemberRemoved: ${channelName} user: ${member}`);
-    const channel: PusherChannel = pusher.getChannel(channelName);
+    const channel: PusherChannel | undefined = pusher.getChannel(channelName);
+
+    if (!channel) {
+      return;
+    }
+
     onChangeMembers([...channel.members.values()]);
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -324,7 +324,7 @@ export class Pusher {
     return await PusherWebsocketReactNative.getSocketId();
   }
 
-  public getChannel(channelName: string): PusherChannel {
-    return this.channels.get(channelName)!;
+  public getChannel(channelName: string): PusherChannel | undefined {
+    return this.channels.get(channelName);
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -179,7 +179,7 @@ export class Pusher {
       const eventName = event.eventName;
       const data = event.data;
       const userId = event.userId;
-      const channel = this.channels.get(channelName)!;
+      const channel = this.channels.get(channelName);
 
       switch (eventName) {
         case 'pusher_internal:subscription_succeeded':
@@ -188,8 +188,8 @@ export class Pusher {
           for (const _userId in decodedData?.presence?.hash) {
             const userInfo = decodedData?.presence?.hash[_userId];
             var member = new PusherMember(_userId, userInfo);
-            channel.members.set(member.userId, member);
-            if (_userId === userId) {
+            channel?.members.set(member.userId, member);
+            if (_userId === userId && channel) {
               channel.me = member;
             }
           }
@@ -199,12 +199,14 @@ export class Pusher {
         case 'pusher_internal:subscription_count':
           // Depending on the platform implementation we get json or a Map.
           var decodedData = data instanceof Object ? data : JSON.parse(data);
-          channel.subscriptionCount = decodedData.subscription_count;
+          if (channel) {
+            channel.subscriptionCount = decodedData.subscription_count;
+          }
           args.onSubscriptionCount?.(
             channelName,
             decodedData.subscription_count
           );
-          channel.onSubscriptionCount?.(decodedData.subscription_count);
+          channel?.onSubscriptionCount?.(decodedData.subscription_count);
           break;
         default:
           const pusherEvent = new PusherEvent(event);


### PR DESCRIPTION
## Description

Forcing a channel to exist when it clearly can be undefined is not good practice. We have had crashes due to `channel` being undefined.

## CHANGELOG

* [FIXED] Channel is an optional, make sure to check if it exists.