### PR TITLE
fix: instead of letting the app crash, handle the exception properly in React Native.

### DIFF
--- a/android/src/main/java/com/pusherwebsocketreactnative/PusherWebsocketReactNativeModule.kt
+++ b/android/src/main/java/com/pusherwebsocketreactnative/PusherWebsocketReactNativeModule.kt
@@ -93,18 +93,22 @@ class PusherWebsocketReactNativeModule(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun subscribe(channelName: String, promise: Promise) {
-    val channel = when {
-      channelName.startsWith("private-encrypted-") -> pusher!!.subscribePrivateEncrypted(
-        channelName, this
-      )
-      channelName.startsWith("private-") -> pusher!!.subscribePrivate(channelName, this)
-      channelName.startsWith("presence-") -> pusher!!.subscribePresence(
-        channelName, this
-      )
-      else -> pusher!!.subscribe(channelName, this)
+    try {
+      val channel = when {
+        channelName.startsWith("private-encrypted-") -> pusher!!.subscribePrivateEncrypted(
+          channelName, this
+        )
+        channelName.startsWith("private-") -> pusher!!.subscribePrivate(channelName, this)
+        channelName.startsWith("presence-") -> pusher!!.subscribePresence(
+          channelName, this
+        )
+        else -> pusher!!.subscribe(channelName, this)
+      }
+      channel.bindGlobal(this)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("Error", "Failed to subscribe to channel: $channelName", e)
     }
-    channel.bindGlobal(this)
-    promise.resolve(null)
   }
 
   @ReactMethod

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -115,7 +115,12 @@ export default function App() {
     log(
       `onSubscriptionSucceeded: ${channelName} data: ${JSON.stringify(data)}`
     );
-    const channel: PusherChannel = pusher.getChannel(channelName);
+    const channel: PusherChannel | undefined = pusher.getChannel(channelName);
+
+    if (!channel) {
+      return;
+    }
+
     const me = channel.me;
     onChangeMembers([...channel.members.values()]);
     log(`Me: ${me}`);
@@ -144,13 +149,23 @@ export default function App() {
 
   const onMemberAdded = (channelName: string, member: PusherMember) => {
     log(`onMemberAdded: ${channelName} user: ${member}`);
-    const channel: PusherChannel = pusher.getChannel(channelName);
+    const channel: PusherChannel | undefined = pusher.getChannel(channelName);
+
+    if (!channel) {
+      return;
+    }
+
     onChangeMembers([...channel.members.values()]);
   };
 
   const onMemberRemoved = (channelName: string, member: PusherMember) => {
     log(`onMemberRemoved: ${channelName} user: ${member}`);
-    const channel: PusherChannel = pusher.getChannel(channelName);
+    const channel: PusherChannel | undefined = pusher.getChannel(channelName);
+
+    if (!channel) {
+      return;
+    }
+
     onChangeMembers([...channel.members.values()]);
   };
 


### PR DESCRIPTION
## Description

Instead of letting the app do a hard crash, make sure that we do a proper `promise.reject()` when we fail to subscribe to the channel.

## CHANGELOG

* [FIXED] Use a `promise.resolve` when you cannot subscribe to a channel.