### PR TITLE
Update README with new getChannel method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.0
+
+* [CHANGED] Use a  when you cannot subscribe to a channel.
+* [FIXED] Now  method returns an optional
+
 ## 1.2.2
 
 * [FIXED] Crash when a user subscribes to a channel twice on Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.3.0
 
-* [CHANGED] Use a promise.resolve when you cannot subscribe to a channel.
+* [CHANGED] Use a promise.resolve when a user cannot subscribe to a channel.
 * [FIXED] Now getChannel method returns an optional
 
 ## 1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.3.0
 
-* [CHANGED] Use a  when you cannot subscribe to a channel.
-* [FIXED] Now  method returns an optional
+* [CHANGED] Use a promise.resolve when you cannot subscribe to a channel.
+* [FIXED] Now getChannel method returns an optional
 
 ## 1.2.2
 

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ For more details, refer to [client events](https://pusher.com/docs/channels/usin
 To get the `PusherChannel` instance from the `Pusher` instance you can use the `getChannel(<channelName>)` method:
 
 ```typescript
-const channel = pusher.getChannel("presence-channel");
+const channel = pusher.getChannel("presence-channel"); // return PusherChannel object or undefined
 ```
 
 ## Socket information

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pusher/pusher-websocket-react-native",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Pusher Channels Client for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## CHANGELOG

* [CHANGED] Use a `promise.resolve` when you cannot subscribe to a channel.
* [FIXED] Now `getChannel` method returns an optional