### PR TITLE
feat: Add resetPusherInstance function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.3
+
+* [ADDED] Add resetPusherInstance function to reset all handlers and subscriptions
+
 ## 1.2.2
 
 * [FIXED] Crash when a user subscribes to a channel twice on Android


### PR DESCRIPTION
# Fixing issue when pusher Instance is initialized multiple times

## Problem

We encountered a critical bug in the project where initializing the Pusher instance multiple times for different users led to the registration of handlers/listeners multiple times. This caused unexpected behavior and performance degradation as well as crashes on android. The root cause was the absence of a mechanism to reset the Pusher instance and clear all the previous listeners and subscribed channels when a different user logged in.

## Solution

To address this issue, I've introduced a new public function named `resetPusherInstance` to the existing class. This function is responsible for performing the necessary cleanup tasks before initializing the Pusher instance for a new user session. Here's what the solution entails:

1. **New Public Function**: Added a new public function `resetPusherInstance` to the class. This function encapsulates the logic to unsubscribe from all the previously subscribed channels and remove all the listeners/handlers associated with the current Pusher instance.

2. **Usage during User Switch**: Whenever a different user logs in, the `resetPusherInstance` function is invoked to ensure that any previous listeners and subscriptions are removed before initializing a new Pusher instance.

3. **Preventing Redundant Listeners**: With this change, we prevent the issue of redundant listeners being registered due to multiple Pusher instance initializations.

## How This Fixes the Issue

By incorporating the `resetPusherInstance` function into the class, we provide a reliable way to reset the Pusher instance's state and prevent the accumulation of redundant listeners and subscriptions. This ensures that each user session starts with a clean slate, mitigating the problem of multiple initialization-related bugs.

## Testing

I've thoroughly tested this solution by simulating various scenarios of user logins and Pusher instance initializations. The tests demonstrate that the `resetPusherInstance` function effectively clears previous state and prevents the bug from occurring.

## Changes Made

- Added the `resetPusherInstance` function to the existing class.
- Updated relevant documentation and comments to explain the new function and its purpose.

## Impact

This contribution not only addresses the bug we encountered but also improves the overall stability and performance of the project when dealing with multiple user sessions.

## Additional Notes

I'm open to feedback and suggestions for further refinement of this solution. Thank you for considering this pull request.

---
