### PR TITLE
Remove all listeners on initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.3.0
 
-* [ADDED] Add  function to  instance to reset all handlers and subscriptions (#110)
+* [ADDED] Add `reset` function to  instance to reset all handlers and subscriptions (#110)
 * [FIXED] Multiple listeners are registered whenever  function is called
 
 ## 1.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.0
+
+* [ADDED] Add  function to  instance to reset all handlers and subscriptions (#110)
+* [FIXED] Multiple listeners are registered whenever  function is called
+
 ## 1.2.3
 
 * [FIXED] Handle exceptions properly while subscribing to a channel on Android (#104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## 1.3.0
 
-* [ADDED] Add `reset` function to  instance to reset all handlers and subscriptions (#110)
-* [FIXED] Multiple listeners are registered whenever  function is called
+* [ADDED] Add `reset` function to `Pusher` instance to reset all handlers and subscriptions (#110)
+* [FIXED] Multiple listeners are registered whenever `init function is called
 
 ## 1.2.3
 
 * [FIXED] Handle exceptions properly while subscribing to a channel on Android (#104)
-
 
 ## 1.2.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pusher/pusher-websocket-react-native",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Pusher Channels Client for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -174,6 +174,8 @@ export class Pusher {
     onMemberAdded?: (channelName: string, member: PusherMember) => void;
     onMemberRemoved?: (channelName: string, member: PusherMember) => void;
   }) {
+    this.removeAllListeners();
+
     this.addListener(
       PusherEventName.ON_CONNECTION_STATE_CHANGE,
       (event: any) => {


### PR DESCRIPTION
## Description

This solves an issue where multiple listeners are registered whenever `init` function is called.

## CHANGELOG

* [ADDED] Add `reset` function to `Pusher` instance to reset all handlers and subscriptions (#110)
* [FIXED] Multiple listeners are registered whenever `init` function is called