### PR TITLE
fix: Add missed events when removing listeners

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -312,6 +312,8 @@ export class Pusher {
     this.pusherEventEmitter.removeAllListeners(
       PusherEventName.ON_MEMBER_REMOVED
     );
+    this.pusherEventEmitter.removeAllListeners(PusherEventName.ON_CONNECTION_STATE_CHANGE);
+    this.pusherEventEmitter.removeAllListeners(PusherEventName.ON_SUBSCRIPTION_ERROR);
   }
 
   public async reset() {


### PR DESCRIPTION
## Description

`removeAllListeners` does not currently remove all listeners.
Added missed event types when removing listeners

## CHANGELOG

[fix: add missed events when removing listeners](https://github.com/pusher/pusher-websocket-react-native/commit/357d56cc81131d4822f155e6af7ca4d86e1d62e7)