### PR TITLE
Pass string to android native instance

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -352,10 +352,11 @@ export class Pusher {
       event.channelName.startsWith('private-') ||
       event.channelName.startsWith('presence-')
     ) {
+      const data = Platform.OS === 'android' ? JSON.stringify(event.data ?? {}) : event.data
       await PusherWebsocketReactNative.trigger(
         event.channelName,
         event.eventName,
-        event.data
+        data
       );
     } else {
       throw 'Trigger event is only for private/presence channels';


### PR DESCRIPTION
## Description

The android native pusher instance for triggering events only accepts data as a string but data is defined as any type (or as an object). Currently, the trigger event function returns an error com.facebook.react.bridge.ReadableNativeMap cannot be cast to java.lang.String. Other users have also experienced this issue here [https://github.com/pusher/pusher-websocket-react-native/issues/147](https://github.com/pusher/pusher-websocket-react-native/issues/147).

## CHANGELOG

* [CHANGED] Fixed error on android "com.facebook.react.bridge.ReadableNativeMap cannot be cast to java.lang.String." when triggering an event to private or presence channels.