### PR TITLE
[SDK] Add host, wsPort, wssPort for configuration

### DIFF
--- a/android/src/main/java/com/pusherwebsocketreactnative/PusherWebsocketReactNativeModule.kt
+++ b/android/src/main/java/com/pusherwebsocketreactnative/PusherWebsocketReactNativeModule.kt
@@ -52,6 +52,9 @@ class PusherWebsocketReactNativeModule(reactContext: ReactApplicationContext) :
         pusher!!.disconnect()
       }
       val options = PusherOptions()
+      if (arguments.hasKey("host")) options.setHost(arguments.getString("host"))
+      if (arguments.hasKey("wsPort")) options.setWsPort(arguments.getInt("wsPort"))
+      if (arguments.hasKey("wssPort")) options.setWssPort(arguments.getInt("wssPort"))
       if (arguments.hasKey("cluster")) options.setCluster(arguments.getString("cluster"))
       if (arguments.hasKey("useTLS")) options.isUseTLS =
         arguments.getBoolean("useTLS")

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -142,6 +142,9 @@ export class Pusher {
   public init(args: {
     apiKey: string;
     cluster: string;
+    host?: string;
+    wsPort?: Number;
+    wssPort?: Number;
     authEndpoint?: string;
     useTLS?: boolean;
     activityTimeout?: Number;
@@ -277,6 +280,9 @@ export class Pusher {
     return PusherWebsocketReactNative.initialize({
       apiKey: args.apiKey,
       cluster: args.cluster,
+      host: args.host,
+      wsPort: args.wsPort,
+      wssPort: args.wssPort,
       authEndpoint: args.authEndpoint,
       useTLS: args.useTLS,
       activityTimeout: args.activityTimeout,


### PR DESCRIPTION
## Description

Both iOS and Android SDKs have `host`, `wsPort` and `wssPort` but RN SDK doesn't allow it. Expose it to RN world, so that configurations are the same!

NOTE: No iOS changes since it takes in a generic dictionary and is handled already by native Swift SDK.