### PR TITLE
fix: updated minSdkVersion to 24

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ def getExtOrIntegerDefault(name) {
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
 
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,5 +14,6 @@
 PusherWebsocketReactNative_kotlinVersion=1.7.21
 PusherWebsocketReactNative_targetSdkVersion=33
 PusherWebsocketReactNative_compileSdkVersion=33
+PusherWebsocketReactNative_minSdkVersion=24
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
## Description

This PR updates the minSdkVersion for the Android build to resolve compatibility issues with newer versions of React Native. Specifically, React Native 0.77.0 requires a minimum SDK version of 24. Without this change, building Android test variants fails due to the mismatch in minimum SDK requirements.

error: uses-sdk:minSdkVersion 21 cannot be smaller than version 24 declared in library [com.facebook.react:react-android:0.77.0]

## CHANGELOG

* [CHANGED] Updated Android minSdkVersion from 21 to 24 to support React Native 0.77.0 and fix Android test variant build failures.