### PR TITLE
chore: consolidate dependabot security updates and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Yarn install
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v6
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 20.x
     - run: yarn install --cwd example --frozen-lockfile
     - run: yarn install --frozen-lockfile
     - run: yarn typescript

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -11,12 +11,12 @@ jobs:
     name: Prepare release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get current version
         run: |
           CURRENT_VERSION=$(npm view @pusher/pusher-websocket-react-native version)
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           repository: pusher/actions
           token: ${{ secrets.PUSHER_CI_GITHUB_PRIVATE_TOKEN }}
@@ -25,9 +25,9 @@ jobs:
         id: bump
         with:
           current_version: ${{ env.CURRENT_VERSION }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: yarn install
       - name: Push
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Prepare tag
@@ -25,7 +25,7 @@ jobs:
         id: release_output
         if: ${{ steps.prepare_tag.outcome == 'success' }}
         run: |
-          echo "::set-output name=tag::${{ env.TAG }}"
+          echo "tag=${{ env.TAG }}" >> $GITHUB_OUTPUT
     outputs:
       tag: ${{ steps.release_output.outputs.tag }}
 
@@ -34,25 +34,25 @@ jobs:
     needs: check-release-tag
     if: ${{ needs.check-release-tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: yarn install
-  
+
   publish-npm:
     runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.check-release-tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org/
           scope: '@pusher'
       - run: yarn install
-      - run: yarn publish --verbose --access public 
+      - run: yarn publish --verbose --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
@@ -61,7 +61,7 @@ jobs:
     needs: publish-npm
     if: ${{ needs.check-release-tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Prepare tag
         run: |
           export TAG=v$(jq -r '.version' package.json)
@@ -79,12 +79,10 @@ jobs:
           csplit -s CHANGELOG.md "/##/" {1}
           cat xx01 > CHANGELOG.tmp
       - name: Create Release
-        uses: actions/create-release@v1
+        run: |
+          gh release create ${{ env.TAG }} \
+            --title "${{ env.TAG }}" \
+            --notes-file CHANGELOG.tmp \
+            $([ "${{ env.PRE_RELEASE }}" = "true" ] && echo "--prerelease")
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.TAG }}
-          release_name: ${{ env.TAG }}
-          body_path: CHANGELOG.tmp
-          draft: false
-          prerelease: ${{ env.PRE_RELEASE }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/example/package.json
+++ b/example/package.json
@@ -23,6 +23,9 @@
   "resolutions": {
     "ip": "^1.1.9",
     "@babel/traverse": "^7.23.9",
-    "react-devtools-core": "^4.28.5"
+    "react-devtools-core": "^4.28.5",
+    "picomatch": "^2.3.2",
+    "minimatch": "^3.1.5",
+    "semver": "^5.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -147,6 +147,11 @@
   "resolutions": {
     "ip": "^1.1.9",
     "@babel/traverse": "^7.23.9",
-    "react-devtools-core": "^4.28.5"
+    "react-devtools-core": "^4.28.5",
+    "handlebars": "^4.7.9",
+    "flatted": "^3.4.2",
+    "picomatch": "^2.3.2",
+    "minimatch": "^3.1.5",
+    "@tootallnate/once": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "flatted": "^3.4.2",
     "picomatch": "^2.3.2",
     "minimatch": "^3.1.5",
-    "@tootallnate/once": "^2.0.0"
+    "@tootallnate/once": "^2.0.0",
+    "lodash": "^4.18.1"
   }
 }


### PR DESCRIPTION
## Summary

Consolidates 6 open Dependabot PRs by pinning vulnerable transitive dependencies via yarn `resolutions`:

- Closes #189 — `minimatch` (example)
- Closes #190 — `@tootallnate/once`
- Closes #191 — `semver` (example)
- Closes #192 — `flatted`
- Closes #193 — `picomatch` (example)
- Closes #194 — `handlebars`

Also updates GitHub Actions to current versions and Node.js from 16.x (EOL) to 20.x.