### PR TITLE
chore: bump workflow Node from 20 to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Yarn install
       uses: actions/setup-node@v6
       with:
-        node-version: 20.x
+        node-version: 24.x
     - run: yarn install --cwd example --frozen-lockfile
     - run: yarn install --frozen-lockfile
     - run: yarn typescript

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -27,7 +27,7 @@ jobs:
           current_version: ${{ env.CURRENT_VERSION }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
       - run: yarn install
       - name: Push
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
       - run: yarn install
 
   publish-npm:
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org/
           scope: '@pusher'
       - run: yarn install


### PR DESCRIPTION
Bumps the Node version used by our workflows from 20 to 24.

Node 20 has reached end-of-life, and some of our dependency updates now require a newer version of Node to install. Moving CI to Node 24 (the current LTS) keeps us on a supported release and unblocks a couple of pending dependency PRs (#203 and #209) that currently fail to install on Node 20.